### PR TITLE
fix: reorder package exports - default export last

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "./sha2": {
       "import": {
         "browser": "./dist/sha2.browser.js",
-        "default": "./dist/sha2.js",
-        "types": "./dist/sha2.d.ts"
+        "types": "./dist/sha2.d.ts",
+        "default": "./dist/sha2.js"
       }
     }
   },


### PR DESCRIPTION
Some bundlers (`webpack`) enforce a "default export comes last" rule.
This causes the build to fail when using the package (directly or indirectly through a library such as `cartonne`).

`NextJS` utilizes `webpack` and is directly affected by this with no apparent workarounds.

Reference to the rule can be found [here](https://webpack.js.org/guides/package-exports/#conditional-syntax):
> The last condition in the object might be the special "default" condition, which is always matched.

\
Example of a build failing before applying the patch:

![image](https://github.com/ukstv/multihashes-sync/assets/34493754/3f6b4065-3d3c-4512-be16-0debb3b7c10f)